### PR TITLE
CenserEffectHandler: Improve Censer performance

### DIFF
--- a/src/main/java/net/grapes/hexalia/HexaliaMod.java
+++ b/src/main/java/net/grapes/hexalia/HexaliaMod.java
@@ -2,6 +2,7 @@ package net.grapes.hexalia;
 
 import com.mojang.logging.LogUtils;
 import net.grapes.hexalia.block.ModBlocks;
+import net.grapes.hexalia.block.ModPoiTypes;
 import net.grapes.hexalia.block.entity.ModBlockEntities;
 import net.grapes.hexalia.effect.ModMobEffects;
 import net.grapes.hexalia.entity.ModEntities;
@@ -55,6 +56,7 @@ public class HexaliaMod
 
         ModItems.register(modEventBus);
         ModBlocks.register(modEventBus);
+        ModPoiTypes.register(modEventBus);
         ModCreativeModeTabs.register(modEventBus);
         ModMobEffects.register(modEventBus);
         ModSounds.register(modEventBus);

--- a/src/main/java/net/grapes/hexalia/block/ModPoiTypes.java
+++ b/src/main/java/net/grapes/hexalia/block/ModPoiTypes.java
@@ -1,0 +1,26 @@
+package net.grapes.hexalia.block;
+
+import com.google.common.collect.ImmutableSet;
+import net.grapes.hexalia.HexaliaMod;
+import net.grapes.hexalia.censer.CenserEffectHandler;
+import net.minecraft.world.entity.ai.village.poi.PoiType;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.RegistryObject;
+
+public class ModPoiTypes {
+	public static final DeferredRegister<PoiType> POI_TYPES = DeferredRegister.create(ForgeRegistries.POI_TYPES, HexaliaMod.MOD_ID);
+	
+	public static RegistryObject<PoiType> CENSER = POI_TYPES.register(
+			"poi_censer",
+			() -> new PoiType(
+					ImmutableSet.of(ModBlocks.CENSER.get().defaultBlockState()),
+					0,
+					CenserEffectHandler.AREA_RADIUS
+			));
+	
+	public static void register(IEventBus eventBus){
+		POI_TYPES.register(eventBus);
+	}
+}

--- a/src/main/java/net/grapes/hexalia/censer/CenserEffectHandler.java
+++ b/src/main/java/net/grapes/hexalia/censer/CenserEffectHandler.java
@@ -1,6 +1,7 @@
 package net.grapes.hexalia.censer;
 
 import net.grapes.hexalia.block.ModBlocks;
+import net.grapes.hexalia.block.ModPoiTypes;
 import net.grapes.hexalia.block.custom.CenserBlock;
 import net.grapes.hexalia.block.entity.CenserBlockEntity;
 import net.grapes.hexalia.item.ModItems;
@@ -12,6 +13,8 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.*;
+import net.minecraft.world.entity.ai.village.poi.PoiManager.Occupancy;
+import net.minecraft.world.entity.ai.village.poi.PoiRecord;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.monster.Monster;
@@ -335,9 +338,11 @@ public class CenserEffectHandler {
             return isUndeadVeilActiveInArea(level, pos);
         }
 
-        AABB area = new AABB(pos).inflate(AREA_RADIUS);
-        return BlockPos.betweenClosedStream(BlockPos.containing(area.minX, area.minY, area.minZ),
-                        BlockPos.containing(area.maxX, area.maxY, area.maxZ))
+        if (!(level instanceof ServerLevel sl)) return false;
+        
+        return sl.getPoiManager()
+                .getInSquare(it -> Objects.equals(it.get(), ModPoiTypes.CENSER.get()), pos, AREA_RADIUS, Occupancy.ANY)
+                .map(PoiRecord::getPos)
                 .map(level::getBlockEntity)
                 .filter(be -> be instanceof CenserBlockEntity)
                 .map(be -> (CenserBlockEntity) be)


### PR DESCRIPTION
Convert Censer to a POI instead of checking all block entities nearby.  Saves a fairly substantial amount of CPU time per entity.