### PR TITLE
Add Conventional Tags to Herb Spawning

### DIFF
--- a/common/src/generated/resources/.cache/aa6e9237a447ea86730c25f624b29c41e674ec46
+++ b/common/src/generated/resources/.cache/aa6e9237a447ea86730c25f624b29c41e674ec46
@@ -1,11 +1,11 @@
-// 1.21.1	2026-05-14T01:36:06.958067	Tags for minecraft:worldgen/biome mod id hexalia
+// 1.21.1	2026-08-03T17:34:22.667547113	Tags for minecraft:worldgen/biome mod id hexalia
 c3d4e55bd4ed5d178abb10df76626eccdab7c209 data/hexalia/tags/worldgen/biome/cacofey_spawns.json
-a98d7d0ca1bdef5682a1928aaee7ce724227c8c0 data/hexalia/tags/worldgen/biome/has_cool_biome_vegetation.json
-27b5c61d0bd6297d6f29b5f49d7a3a7d52b5e029 data/hexalia/tags/worldgen/biome/has_decorative_flowers.json
-f3da22dde9ab58a75ef89f5f43dcadc698e760f5 data/hexalia/tags/worldgen/biome/has_dry_biome_vegetation.json
-41fa040d0fb54e6268ac13a1ca75a845fa1824d0 data/hexalia/tags/worldgen/biome/has_floral_vegetation.json
-5f176659fa27569cc678ddae4a306c2055a89a16 data/hexalia/tags/worldgen/biome/has_shaded_vegetation.json
-6b5b6188dc8d42fef0fbcbba6e03e9cd3a3a88d7 data/hexalia/tags/worldgen/biome/has_shrooms.json
+eb607ad56f6cb9e9a2c03a883162cf77c9cb1994 data/hexalia/tags/worldgen/biome/has_cool_biome_vegetation.json
+42bf0939856d7fbed28fe4d46d9a1b11e080e079 data/hexalia/tags/worldgen/biome/has_decorative_flowers.json
+16212958778da8388279b0dba1bf0f1333fbae90 data/hexalia/tags/worldgen/biome/has_dry_biome_vegetation.json
+e656596fc80389a4082818c72ef6428835beaa40 data/hexalia/tags/worldgen/biome/has_floral_vegetation.json
+6c4166f36e1414b0b9063059a26fbc7c2f3c3b98 data/hexalia/tags/worldgen/biome/has_shaded_vegetation.json
+aab5a21e179850676aa7a1d01e3437a890dc8cc2 data/hexalia/tags/worldgen/biome/has_shrooms.json
 afd9da16b8e57511d3b12c69ccd4555d71ebb29f data/hexalia/tags/worldgen/biome/has_siren_kelp.json
-3e00d0ecf4c9744bbf1b1c80ff5270a55488fc87 data/hexalia/tags/worldgen/biome/has_swamp_vegetation.json
+07339991a37b81fcf4b9890fa18de034e1a9be8e data/hexalia/tags/worldgen/biome/has_swamp_vegetation.json
 6b35771c8d400b0921c04386d79e88b834c282ad data/hexalia/tags/worldgen/biome/silk_moth_spawns.json

--- a/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_cool_biome_vegetation.json
+++ b/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_cool_biome_vegetation.json
@@ -1,8 +1,6 @@
 {
   "values": [
-    "minecraft:taiga",
-    "minecraft:old_growth_spruce_taiga",
-    "minecraft:snowy_taiga",
+    "#minecraft:is_taiga",
     "minecraft:snowy_plains"
   ]
 }

--- a/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_decorative_flowers.json
+++ b/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_decorative_flowers.json
@@ -1,6 +1,18 @@
 {
   "values": [
     "minecraft:sunflower_plains",
-    "minecraft:plains"
+    "minecraft:plains",
+    {
+      "id": "#c:is_flower_forest",
+      "required": false
+    },
+    {
+      "id": "#c:is_floral",
+      "required": false
+    },
+    {
+      "id": "#c:is_plains",
+      "required": false
+    }
   ]
 }

--- a/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_dry_biome_vegetation.json
+++ b/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_dry_biome_vegetation.json
@@ -3,6 +3,10 @@
     "minecraft:desert",
     "minecraft:badlands",
     "minecraft:windswept_savanna",
-    "minecraft:savanna"
+    "minecraft:savanna",
+    {
+      "id": "#c:is_dry/overworld",
+      "required": false
+    }
   ]
 }

--- a/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_floral_vegetation.json
+++ b/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_floral_vegetation.json
@@ -3,6 +3,14 @@
     "minecraft:meadow",
     "minecraft:old_growth_birch_forest",
     "minecraft:birch_forest",
-    "minecraft:flower_forest"
+    "minecraft:flower_forest",
+    {
+      "id": "#c:is_flower_forest",
+      "required": false
+    },
+    {
+      "id": "#c:is_floral",
+      "required": false
+    }
   ]
 }

--- a/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_shaded_vegetation.json
+++ b/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_shaded_vegetation.json
@@ -1,5 +1,17 @@
 {
   "values": [
-    "minecraft:dark_forest"
+    "minecraft:dark_forest",
+    {
+      "id": "#c:is_old_growth",
+      "required": false
+    },
+    {
+      "id": "#c:is_dense_vegetation/overworld",
+      "required": false
+    },
+    {
+      "id": "#c:is_dark_forest",
+      "required": false
+    }
   ]
 }

--- a/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_shrooms.json
+++ b/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_shrooms.json
@@ -1,6 +1,10 @@
 {
   "values": [
     "minecraft:old_growth_pine_taiga",
-    "minecraft:mushroom_fields"
+    "minecraft:mushroom_fields",
+    {
+      "id": "#c:is_mushroom",
+      "required": false
+    }
   ]
 }

--- a/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_swamp_vegetation.json
+++ b/common/src/generated/resources/data/hexalia/tags/worldgen/biome/has_swamp_vegetation.json
@@ -1,6 +1,10 @@
 {
   "values": [
     "minecraft:mangrove_swamp",
-    "minecraft:swamp"
+    "minecraft:swamp",
+    {
+      "id": "#c:is_swamp",
+      "required": false
+    }
   ]
 }

--- a/neoforge/src/main/java/net/astralya/hexalia/neoforge/datagen/ModBiomeTagsProvider.java
+++ b/neoforge/src/main/java/net/astralya/hexalia/neoforge/datagen/ModBiomeTagsProvider.java
@@ -6,6 +6,7 @@ import net.astralya.hexalia.util.ModTags;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.BiomeTagsProvider;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.BiomeTags;
 import net.minecraft.world.level.biome.Biomes;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
@@ -24,32 +25,45 @@ public class ModBiomeTagsProvider extends BiomeTagsProvider {
         .add(Biomes.MEADOW)
         .add(Biomes.OLD_GROWTH_BIRCH_FOREST)
         .add(Biomes.BIRCH_FOREST)
-        .add(Biomes.FLOWER_FOREST);
+        .add(Biomes.FLOWER_FOREST)
+        .addOptionalTag(conventional("is_flower_forest"))
+        .addOptionalTag(conventional("is_floral"));
 
     tag(ModTags.Biomes.HAS_COOL_BIOME_VEGETATION)
-        .add(Biomes.TAIGA)
-        .add(Biomes.OLD_GROWTH_SPRUCE_TAIGA)
-        .add(Biomes.SNOWY_TAIGA)
+        .addTag(BiomeTags.IS_TAIGA)
         .add(Biomes.SNOWY_PLAINS);
 
     tag(ModTags.Biomes.HAS_DRY_BIOME_VEGETATION)
         .add(Biomes.DESERT)
         .add(Biomes.BADLANDS)
         .add(Biomes.WINDSWEPT_SAVANNA)
-        .add(Biomes.SAVANNA);
+        .add(Biomes.SAVANNA)
+        .addOptionalTag(conventional("is_dry/overworld"));
 
-    tag(ModTags.Biomes.HAS_SHROOMS).add(Biomes.OLD_GROWTH_PINE_TAIGA).add(Biomes.MUSHROOM_FIELDS);
+    tag(ModTags.Biomes.HAS_SHROOMS).add(Biomes.OLD_GROWTH_PINE_TAIGA).add(Biomes.MUSHROOM_FIELDS)
+        .addOptionalTag(conventional("is_mushroom"));
 
     tag(ModTags.Biomes.HAS_SIREN_KELP).addTag(BiomeTags.IS_OCEAN);
 
-    tag(ModTags.Biomes.HAS_SWAMP_VEGETATION).add(Biomes.MANGROVE_SWAMP).add(Biomes.SWAMP);
+    tag(ModTags.Biomes.HAS_SWAMP_VEGETATION).add(Biomes.MANGROVE_SWAMP).add(Biomes.SWAMP)
+        .addOptionalTag(conventional("is_swamp"));
 
-    tag(ModTags.Biomes.HAS_SHADED_VEGETATION).add(Biomes.DARK_FOREST);
+    tag(ModTags.Biomes.HAS_SHADED_VEGETATION).add(Biomes.DARK_FOREST)
+        .addOptionalTag(conventional("is_old_growth"))
+        .addOptionalTag(conventional("is_dense_vegetation/overworld"))
+        .addOptionalTag(conventional("is_dark_forest"));
 
-    tag(ModTags.Biomes.HAS_DECORATIVE_FLOWERS).add(Biomes.SUNFLOWER_PLAINS).add(Biomes.PLAINS);
+    tag(ModTags.Biomes.HAS_DECORATIVE_FLOWERS).add(Biomes.SUNFLOWER_PLAINS).add(Biomes.PLAINS)
+        .addOptionalTag(conventional("is_flower_forest"))
+        .addOptionalTag(conventional("is_floral"))
+        .addOptionalTag(conventional("is_plains"));
 
     tag(ModTags.Biomes.SILK_MOTH_SPAWNS).addTag(BiomeTags.IS_FOREST);
 
     tag(ModTags.Biomes.CACOFEY_SPAWNS).addTag(BiomeTags.IS_JUNGLE);
+  }
+
+  private static ResourceLocation conventional(String path) {
+    return ResourceLocation.fromNamespaceAndPath("c", path);
   }
 }


### PR DESCRIPTION
Currently, the Hexalia worldgen tags use a combination of Minecraft tags and specific biomes. I use several biome mods, and they seem to do a pretty good job placing their biomes into the Minecraft namespace when there's a relevant tag. However, there often isn't one, so I would much appreciate seeing these 'conventional' tags added. I think the ones I've added in this PR will be enough for compatibility with any reasonably made mod across NeoForge or Fabric.

A few notes:
- In `has_cool_biome_vegetation` I replaced three biomes with the `is_taiga` Minecraft tag, which adds them back *and* adds `old_growth_pine_taiga`. Was this meant to be left out?
- I thought all the tags matched well besides what I did in `has_decorative_flowers` -- the new tags might expand the biome pool for this beyond what you intended.
- I saw ModTags but wasn't sure if you wanted these references hoisted there also. It seemed most expedient to just do the tags inline.
- I don't see why these tags wouldn't be present on either loader, but I made them optional just in case. I figure that also makes it safer to sprinkle in the newest possible tags and not worry about versioning.
